### PR TITLE
修复 #22

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,9 @@ class SkeletonPlugin {
 
                 // find current processing entry
                 if (Array.isArray(usedChunks)) {
+                    if (usedChunks.length === 0) {
+                        usedChunks = htmlPluginData.plugin.options.chunks;
+                    }
                     entryKey = Object.keys(skeletonEntries).find(v => usedChunks.indexOf(v) > -1);
                 }
                 else {


### PR DESCRIPTION
HtmlWebpackPlugin如果指定了chunks参数，在htmlPluginData.assets.chunks将获取不到，只能拿到空数组。
需要从htmlPluginData.plugin.options.chunks获取。
当然如果配置不正确依然会有报错。